### PR TITLE
feat: Add client options support

### DIFF
--- a/initializer_test.go
+++ b/initializer_test.go
@@ -1,12 +1,26 @@
 package azuremonitormetricsreceiver
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCreateAzureClients_WithoutCustomOptions(t *testing.T) {
+	_, err := CreateAzureClients(testSubscriptionID, testClientID, testClientSecret, testTenantID)
+	require.NoError(t, err)
+}
+
+func TestCreateAzureClients_WithCustomOptions(t *testing.T) {
+	options := &azcore.ClientOptions{Cloud: cloud.AzureGovernment}
+	_, err := CreateAzureClients(testSubscriptionID, testClientID, testClientSecret, testTenantID, WithAzureClientOptions(options))
+
+	require.NoError(t, err)
+}
 
 func TestCheckConfigValidation_ResourceTargetsOnly(t *testing.T) {
 	ammr := &AzureMonitorMetricsReceiver{


### PR DESCRIPTION
- The PR adds ClientOptions to support the client. It is necessary to communicate with the Azure Sovereign Cloud solutions.

**Possible Test cases and follow-ups:**
- [x] Integrate the options inside Telegraf a test the new options.